### PR TITLE
simplify recipe using conda-build 3

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,6 @@
-"%PYTHON%" setup.py configure --hdf5="%LIBRARY_PREFIX%"  --hdf5-version=1.8.18
+:: hdf5 env var provided by conda-build 3 variant
+python setup.py configure --hdf5="%LIBRARY_PREFIX%"  --hdf5-version=%hdf5%
 if errorlevel 1 exit 1
 
-"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+python setup.py install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,19 +14,18 @@ build:
 
 requirements:
   build:
+    - hdf5
     - python
     - setuptools
-    - numpy x.x
-    - hdf5 1.8.18|1.8.18.*
+    - numpy
     - cython
     - six
     - pkgconfig
 
   run:
+    - hdf5
+    - numpy
     - python
-    - numpy x.x
-    # when this is changed also update bld.bat
-    - hdf5 1.8.18|1.8.18.*
     - six
     - unittest2    # [py26]
 


### PR DESCRIPTION
This updates to @jjhelmus new numpy style, and uses cb3 functionality to more intelligently pin hdf5.

This modification assumes a top-level conda_build_config.yaml file that is not present in this folder (so that this folder doesn't override user-wide settings.)  Example content for that file:

```
numpy:
  - 1.7  # [py<34]
  - 1.9  # [py35]
  - 1.11  # [py>35]
hdf5:
  - 1.8.18
```

CC @nehaljwani 