### PR TITLE
h5py 3.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.5.0" %}
+{% set version = "3.6.0" %}
 {% set build = 0 %}
 
 # mpi must be defined for conda-smithy lint
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://github.com/h5py/h5py/archive/{{ version }}.tar.gz
-  sha256: b9876e15540b8bf1eb434de8e3751721146f7d0e015f9b235ec11fd774f82616
+  sha256: 840fca0787bca8ad2729b9c20e06a16f219e7a24ccc59fdf5177a05ec8472b2d
   patches:
     # override setup.py specified minimum compatible numpy versions
     # we take care of those via numpy pinning below

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,6 @@ source:
   url: https://github.com/h5py/h5py/archive/{{ version }}.tar.gz
   sha256: 840fca0787bca8ad2729b9c20e06a16f219e7a24ccc59fdf5177a05ec8472b2d
   patches:
-    # override setup.py specified minimum compatible numpy versions
-    # we take care of those via numpy pinning below
-    - adjust-minimum-numpy-run-versions.patch
     - osx-arm64.diff    # [osx and arm64]
     - osx-arm64-hdf5.diff    # [osx and arm64]
 
@@ -39,7 +36,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python
+    - python >=3.7
     - cached-property  # [py<38]
     - {{ pin_compatible('numpy') }}
     # hdf5 >=1.10.4 has run_exports
@@ -49,6 +46,10 @@ requirements:
 test:
   imports:
     - h5py
+    - h5py._hl
+    - h5py.tests
+    - h5py.tests.data_files
+    - h5py.tests.test_vds
   requires:
     - pip
     - pytest


### PR DESCRIPTION
Update h5py to 3.6.0

Version change: bump version number from 3.5.0 to 3.6.0
Bug Tracker: new open issues https://github.com/h5py/h5py/issues
Upstream license:  License file:  https://github.com/h5py/h5py/blob/master/LICENSE
Upstream setup.py:  https://github.com/h5py/h5py/blob/3.6.0/setup.py
Upstream pyproject.toml:  https://github.com/h5py/h5py/blob/3.6.0/pyproject.toml

The package h5py is mentioned inside the packages:
blaze | caffe | caffe-gpu | fuel | glue-core | keras | keras-applications | neon | yt |

Actions:
1. Remove one patch
2. In run: `python >=3.7`
3. Add test/imports

Result:
- all-succeeded