### PR TITLE
Remove pyreadline from run requirements in recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.6.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # mpi must be defined for conda-smithy lint
 {% set mpi = mpi or 'nompi' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ requirements:
     - {{ pin_compatible('numpy') }}
     # hdf5 >=1.10.4 has run_exports
     - hdf5
-    - pyreadline  # [win]
 
 test:
   imports:


### PR DESCRIPTION
Since version 3.5 h5py does not depend on pyreadline anymore while pyreadline breaks the python repl for python >= 3.10 on windows