### PR TITLE
h5py 3.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "h5py" %}
-{% set version = "3.7.0" %}
+{% set version = "3.8.0" %}
 {% set build = 0 %}
 
 # mpi must be defined for conda-smithy lint
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 71ee0e0a25d6acc5e99ff13c287cae006604f6054dd9b60c352d0216e5d6b6f4
+  sha256: 1ec05e67b246a50142762de1bd008022366562d749fd508417ba3286a4a692ad
 
 build:
   skip: True  # [py<=36]


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index e22664c..414c98c 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "h5py" %}
-{% set version = "3.7.0" %}
+{% set version = "3.8.0" %}
 {% set build = 0 %}
 
 # mpi must be defined for conda-smithy lint
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 71ee0e0a25d6acc5e99ff13c287cae006604f6054dd9b60c352d0216e5d6b6f4
+  sha256: 1ec05e67b246a50142762de1bd008022366562d749fd508417ba3286a4a692ad
 
 build:
   skip: True  # [py<=36]

```

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/h5py/h5py/releases
[Diff between the latest and previous upstream releases](https://github.com/h5py/h5py/compare/3.7.0...3.8.0)
License: https://github.com/h5py/h5py/blob/master/LICENSE
Requirements:
 * setup.py:  https://github.com/h5py/h5py/blob/3.8.0/setup.py
 * pyproject.toml:  https://github.com/h5py/h5py/blob/3.8.0/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 3.8.0
 * Release on PyPi:
    * version: 3.8.0
    * date: 2023-01-23T10:27:37
* [PyPi history](https://pypi.org/project/h5py/#history)
 * Popularity: 
    * 3 months downloads: 1152915.0
    * All time:  10549220 downloads -  h5py  3.8.0  Read and write HDF5 files from Python  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: licenses/license.txt is present

14. - [x] license_family BSD is present
16. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check dependency issues:**

<details>
../aggregate/h5py-feedstock/recipe/meta.yaml
Dependencies: ['pkgconfig', 'wheel', 'pip', 'python', 'setuptools', 'cython >=0.29.15', 'numpy', 'hdf5']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  Encountered problems while solving:
  - nothing provides m2w64-pkg-config needed by pkgconfig-1.2.2-py27h878d913_1

- py3.8:  Encountered problems while solving:
  - nothing provides m2w64-pkg-config needed by pkgconfig-1.2.2-py27h878d913_1

- py3.9:  Encountered problems while solving:
  - nothing provides m2w64-pkg-config needed by pkgconfig-1.2.2-py27h878d913_1

- py3.10:  No issues found

</details>

**Package Build Score: expected token 'end of print statement', got 'c'
None**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/h5py-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/h5py-feedstock/tree/3.8.0)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/h5py)
* [Diff between upstream and feature branch](https://github.com/conda-forge/h5py-feedstock/compare/main...AnacondaRecipes:3.8.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/h5py-feedstock/compare/master...AnacondaRecipes:3.8.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/h5py-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 3.8.0 git@github.com:AnacondaRecipes/h5py-feedstock.git
```
