### PR TITLE
Use hdf5 1.12.1 on all platforms to have consistent dependencies

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,5 +3,5 @@ set HDF5_DIR="%LIBRARY_PREFIX%"
 REM tell setup.py to not 'pip install' exact package requirements
 set H5PY_SETUP_REQUIRES=0
 
-"%PYTHON%" -m pip install . --no-deps --ignore-installed --no-cache-dir -vv
+"%PYTHON%" -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,3 @@
-set HDF5_VERSION=%hdf5%
 set HDF5_DIR="%LIBRARY_PREFIX%"
 
 REM tell setup.py to not 'pip install' exact package requirements

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,4 +9,4 @@ fi
 # tell setup.py to not 'pip install' exact package requirements
 export H5PY_SETUP_REQUIRES="0"
 
-"${PYTHON}" -m pip install . --no-deps --ignore-installed --no-cache-dir -vv
+"${PYTHON}" -m pip install . --ignore-installed --no-cache-dir -vv --no-deps --no-build-isolation

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-export HDF5_VERSION=${hdf5}
 export HDF5_DIR=${PREFIX}
 export OPAL_PREFIX=${PREFIX}
 if [[ "$mpi" != "nompi" ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python
     - cython >=0.29.15,<3
     - hdf5 1.12.1
-    - numpy
+    - numpy {{ numpy }}
     - pip
     - pkgconfig
     - setuptools
@@ -53,6 +53,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: licenses/license.txt
+  description: Read and write HDF5 files from Python
   summary: Read and write HDF5 files from Python
   dev_url: https://github.com/h5py/h5py
   doc_url: https://docs.h5py.org/en/stable/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "h5py" %}
 {% set version = "3.7.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # mpi must be defined for conda-smithy lint
 {% set mpi = mpi or 'nompi' %}
@@ -14,7 +14,7 @@ source:
   sha256: 71ee0e0a25d6acc5e99ff13c287cae006604f6054dd9b60c352d0216e5d6b6f4
 
 build:
-  skip: True  # [py<=36]
+  skip: True  # [py<38]
   number: {{ build }}
 
 requirements:
@@ -22,8 +22,8 @@ requirements:
     - {{ compiler("c") }}
   host:
     - python
-    - cython >=0.29.15
-    - hdf5
+    - cython >=0.29.15,<3
+    - hdf5 1.12.1
     - numpy
     - pip
     - pkgconfig
@@ -31,8 +31,7 @@ requirements:
     - wheel
   run:
     - python
-    # hdf5 >=1.10.4 has run_exports
-    - hdf5
+    - hdf5  # exact pin handled through hdf5 run_exports
     - {{ pin_compatible('numpy') }}
 
 test:


### PR DESCRIPTION
Use hdf5 1.12.1 on all platforms to have consistent dependencies.