### PR TITLE
h5py 3.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "h5py" %}
-{% set version = "3.9.0" %}
+{% set version = "3.11.0" %}
 {% set build = 0 %}
 
 # mpi must be defined for conda-smithy lint
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: ac46f5caae570c9312edea6f65ad4e894e8da44a868b7f263e15265bc3de7a16
+  sha256: 034ec21f28f2f2edc4542515a9ae45356a25bb459048acf9622e6b1143b3fae7
 
 build:
   skip: True  # [py<38]
@@ -22,8 +22,10 @@ requirements:
     - {{ compiler("c") }}
   host:
     - python
-    - cython >=0.29.15,<3
+    - cython >=0.29.15,<4
     - hdf5 1.12.1
+    # The upstream source added compatibility to build with numpy 2.0
+    # but it still can be done with numpy 1.x, see https://github.com/h5py/h5py/pull/2401
     - numpy {{ numpy }}
     - pip
     - pkgconfig
@@ -56,7 +58,7 @@ about:
   description: Read and write HDF5 files from Python
   summary: Read and write HDF5 files from Python
   dev_url: https://github.com/h5py/h5py
-  doc_url: https://docs.h5py.org/en/stable/
+  doc_url: https://docs.h5py.org
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-3594](https://anaconda.atlassian.net/browse/PKG-3594) 
- [Upstream repository](https://github.com/h5py/h5py/tree/3.11.0)
- Requirements:
  - https://github.com/h5py/h5py/blob/3.11.0/pyproject.toml
  - https://github.com/h5py/h5py/blob/3.11.0/setup.py
  - https://github.com/h5py/h5py/blob/3.11.0/setup_build.py
  - https://github.com/h5py/h5py/blob/3.11.0/setup_configure.py 

### Explanation of changes:

- Despite [saying](https://github.com/h5py/h5py/blob/3.11.0/pyproject.toml#L5) that to build h5py you need numpy >=2.0 rc1 with py>=39 there is only adding compatibility to build with Numpy 2.0, see  https://github.com/h5py/h5py/blob/3.11.0/docs/whatsnew/3.11.rst#new-features and only new tests are added trying it https://github.com/h5py/h5py/pull/2401. I left a comment


[PKG-3594]: https://anaconda.atlassian.net/browse/PKG-3594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ