### PR TITLE
Rebuild with hdf5 1.14.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,1 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/hdf5-feedstock/pr13/88e658e
+pbp_autopublish: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/hdf5-feedstock/pr13/88e658e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   host:
     - python
     - cython >=0.29.31,<4
-    - hdf5 1.14.5
+    - hdf5 {{ hdf5 }}
     - numpy >=2.0.0, <3
     - pip
     - pkgconfig

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   skip: True  # [py<39]
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -22,7 +22,7 @@ requirements:
   host:
     - python
     - cython >=0.29.31,<4
-    - hdf5 1.12.1
+    - hdf5 1.14.5
     - numpy >=2.0.0, <3
     - pip
     - pkgconfig


### PR DESCRIPTION
h5py v3.12.1 build 1

**Destination channel:**  defaults

### Links

- [PKG-6126](https://anaconda.atlassian.net/browse/PKG-6126) 
- [Upstream repository](https://github.com/h5py/h5py/tree/3.12.1)

### Explanation of changes:

- Rebuild with hdf5 1.14.5


[PKG-6126]: https://anaconda.atlassian.net/browse/PKG-6126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ