### PR TITLE
hdf5 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   skip: True  # [py<39]
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
The latest hdf5 is necessitating a rebuild. 


## Reproduce
```
conda create -n h5py_test h5py
conda activate h5py_test
python -c "import h5py"  
```

##Result
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/lundby/miniconda3/envs/hdf5_test/lib/python3.12/site-packages/h5py/__init__.py", line 33, in <module>
    from . import version
  File "/Users/lundby/miniconda3/envs/hdf5_test/lib/python3.12/site-packages/h5py/version.py", line 15, in <module>
    from . import h5 as _h5
  File "h5py/h5.pyx", line 1, in init h5py.h5
ImportError: dlopen(/Users/lundby/miniconda3/envs/hdf5_test/lib/python3.12/site-packages/h5py/defs.cpython-312-darwin.so, 0x0002): Symbol not found: _H5Pget_fapl_ros3
  Referenced from: <8E360924-28BE-3200-8E47-DAA59B65F998> /Users/lundby/miniconda3/envs/hdf5_test/lib/python3.12/site-packages/h5py/defs.cpython-312-darwin.so
  Expected in:     <A1E4320C-2171-3155-BA33-1E4380223C7F> /Users/lundby/miniconda3/envs/hdf5_test/lib/libhdf5.310.5.0.dylib
```

### Test Fix
```
conda install -c https://staging.continuum.io/prefect/fs/h5py-feedstock/pr18/9ea0cac h5py
python -c "import h5py"  
```