### PR TITLE
h5py 3.14.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "h5py" %}
-{% set version = "3.13.0" %}
+{% set version = "3.14.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,17 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: d16d0f02e24aed3ba8eb59e406aa44a24f6295c4ad7d85ad4ec6bc0ea176a24e
+  sha256: 4937c1cbef049fd28973494def11084b70c1d218c6898a9d8cfb471c84010a99
+  patches:
+    - patches/0001-fix-license-in-pyproject.toml.patch
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<39]
+  build:
+    - patch  # [not win]
+    - m2-patch  # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,9 @@ source:
   sha256: 4937c1cbef049fd28973494def11084b70c1d218c6898a9d8cfb471c84010a99
   patches:
     - patches/0001-fix-license-in-pyproject.toml.patch
+    # Disable complex256 for arm64
+    # follow https://github.com/conda-forge/cross-python-feedstock/issues/92
+    - patches/0002-disable-numpy-complex256-osx-arm.patch   # [osx and arm64]
 
 build:
   number: 0
@@ -90,7 +93,10 @@ about:
   summary: The h5py package is a Pythonic interface to the HDF5 binary data format.
   license: BSD-3-Clause
   license_family: BSD
-  license_file: licenses/license.txt
+  license_file:
+    - licenses/license.txt
+    - LICENSE
+    - lzf/LICENSE.txt
   description: |
     HDF5 lets you store huge amounts of numerical data, and easily manipulate that data from NumPy.
     For example, you can slice into multi-terabyte datasets stored on disk, as if they were real NumPy arrays.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,12 +15,11 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<39]
-  build:
-    - patch  # [not win]
-    - m2-patch  # [win]
 
 requirements:
   build:
+    - patch  # [not win]
+    - m2-patch  # [win]
     - {{ compiler("c") }}
   host:
     - python

--- a/recipe/patches/0001-fix-license-in-pyproject.toml.patch
+++ b/recipe/patches/0001-fix-license-in-pyproject.toml.patch
@@ -1,0 +1,26 @@
+From bac2f3ee35f1d13be0e90301365c93accb27a3f4 Mon Sep 17 00:00:00 2001
+From: PatrykKups <pkups@anaconda.com>
+Date: Tue, 24 Jun 2025 20:37:46 +0200
+Subject: [PATCH] patch
+
+---
+ pyproject.toml | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 45d3da8..f8abaa3 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -19,8 +19,7 @@ maintainers = [
+     {name = "Thomas Kluyver", email = "thomas@kluyver.me.uk"},
+     {name = "Thomas A Caswell", email = "tcaswell@bnl.gov"},
+ ]
+-license = "BSD-3-Clause"
+-license-files = ["LICENSE", "lzf/LICENSE.txt", "licenses/*"]
++license = {text = "BSD-3-Clause"}
+ classifiers = [
+     "Development Status :: 5 - Production/Stable",
+     "Intended Audience :: Developers",
+-- 
+2.39.5 (Apple Git-154)
+

--- a/recipe/patches/0002-disable-numpy-complex256-osx-arm.patch
+++ b/recipe/patches/0002-disable-numpy-complex256-osx-arm.patch
@@ -1,0 +1,25 @@
+From 3ad69c46f478d466bdbb18b3944726fafe1b4516 Mon Sep 17 00:00:00 2001
+From: PatrykKups <pkups@anaconda.com>
+Date: Wed, 25 Jun 2025 13:30:17 +0200
+Subject: [PATCH] disable numpy complex256 osx arm
+
+---
+ setup_build.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup_build.py b/setup_build.py
+index 9b4766e..56df539 100644
+--- a/setup_build.py
++++ b/setup_build.py
+@@ -142,7 +142,7 @@ class h5py_build_ext(build_ext):
+         from Cython.Build import cythonize
+         import numpy
+ 
+-        complex256_support = hasattr(numpy, 'complex256')
++        complex256_support = False
+ 
+         # This allows ccache to recognise the files when pip builds in a temp
+         # directory. It speeds up repeatedly running tests through tox with
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
h5py 3.14.0 

**Destination channel:** Defaults

### Links

- [PKG-8551]
- dev_url:        https://github.com/h5py/h5py/tree/3.14.0
- conda_forge:    https://github.com/conda-forge/h5py-feedstock
- pypi:           https://pypi.org/project/h5py/3.14.0
- pypi inspector: https://inspector.pypi.io/project/h5py/3.14.0

### Explanation of changes:

- new version number


[PKG-8551]: https://anaconda.atlassian.net/browse/PKG-8551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ